### PR TITLE
Resolves: #48 - Updated image sources on views/products/edit and index

### DIFF
--- a/mtg-storefront/resources/views/products/create.blade.php
+++ b/mtg-storefront/resources/views/products/create.blade.php
@@ -87,32 +87,32 @@
                 <label class="block text-sm font-medium text-gray-700 mb-2">Color</label>
                 <div class="flex flex-wrap gap-2">
 
-                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-[:checked]:bg-yellow-50 has-[:checked]:border-yellow-400 has-[:checked]:text-yellow-700 transition">
+                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-checked:bg-yellow-50 has-checked:border-yellow-400 has-checked:text-yellow-700 transition">
                         <input type="checkbox" name="color[]" value="White" class="hidden" />
                         White
                     </label>
 
-                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-[:checked]:bg-blue-50 has-[:checked]:border-blue-400 has-[:checked]:text-blue-700 transition">
+                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-checked:bg-blue-50 has-checked:border-blue-400 has-checked:text-blue-700 transition">
                         <input type="checkbox" name="color[]" value="Blue" class="hidden" />
                         Blue
                     </label>
 
-                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-[:checked]:bg-gray-100 has-[:checked]:border-gray-500 has-[:checked]:text-gray-800 transition">
+                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-checked:bg-gray-100 has-checked:border-gray-500 has-checked:text-gray-800 transition">
                         <input type="checkbox" name="color[]" value="Black" class="hidden" />
                         Black
                     </label>
 
-                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-[:checked]:bg-red-50 has-[:checked]:border-red-400 has-[:checked]:text-red-700 transition">
+                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-checked:bg-red-50 has-checked:border-red-400 has-checked:text-red-700 transition">
                         <input type="checkbox" name="color[]" value="Red" class="hidden" />
                         Red
                     </label>
 
-                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-[:checked]:bg-green-50 has-[:checked]:border-green-400 has-[:checked]:text-green-700 transition">
+                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-checked:bg-green-50 has-checked:border-green-400 has-checked:text-green-700 transition">
                         <input type="checkbox" name="color[]" value="Green" class="hidden" />
                         Green
                     </label>
 
-                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-[:checked]:bg-purple-50 has-[:checked]:border-purple-400 has-[:checked]:text-purple-700 transition">
+                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-checked:bg-purple-50 has-checked:border-purple-400 has-checked:text-purple-700 transition">
                         <input type="checkbox" name="color[]" value="Colorless" class="hidden" />
                         Colorless
                     </label>

--- a/mtg-storefront/resources/views/products/edit.blade.php
+++ b/mtg-storefront/resources/views/products/edit.blade.php
@@ -52,7 +52,7 @@
             <label for="image" class="block text-sm font-medium text-gray-700 mb-1">Product Image</label>
             @if($product->image)
                 <div class="mb-3">
-                    <img src="{{ asset('storage/' . $product->image) }}" class="h-32 w-32 object-cover rounded-md border border-gray-300 mb-2" />
+                    <img src="{{ $product->image ? (Str::startsWith($product->image, 'http') ? $product->image : asset('storage/' . $product->image)) : 'https://placehold.co/400x400?text=No+Image+Uploaded' }}" class="h-32 w-32 object-cover rounded-md border border-gray-300 mb-2" />
                     <label class="flex items-center gap-2 text-sm text-red-600 cursor-pointer">
                         <input type="checkbox" name="remove_image" value="1" />
                         Remove current image
@@ -103,32 +103,32 @@
                 <label class="block text-sm font-medium text-gray-700 mb-2">Color</label>
                 <div class="flex flex-wrap gap-2">
 
-                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-[:checked]:bg-yellow-50 has-[:checked]:border-yellow-400 has-[:checked]:text-yellow-700 transition">
+                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-checked:bg-yellow-50 has-checked:border-yellow-400 has-checked:text-yellow-700 transition">
                         <input type="checkbox" name="color[]" value="White" {{ in_array('White', $colors) ? 'checked' : '' }} class="hidden" />
                         White
                     </label>
 
-                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-[:checked]:bg-blue-50 has-[:checked]:border-blue-400 has-[:checked]:text-blue-700 transition">
+                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-checked:bg-blue-50 has-checked:border-blue-400 has-checked:text-blue-700 transition">
                         <input type="checkbox" name="color[]" value="Blue" {{ in_array('Blue', $colors) ? 'checked' : '' }}  class="hidden" />
                         Blue
                     </label>
 
-                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-[:checked]:bg-gray-100 has-[:checked]:border-gray-500 has-[:checked]:text-gray-800 transition">
+                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-checked:bg-gray-100 has-checked:border-gray-500 has-checked:text-gray-800 transition">
                         <input type="checkbox" name="color[]" value="Black" {{ in_array('Black', $colors) ? 'checked' : '' }}  class="hidden" />
                         Black
                     </label>
 
-                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-[:checked]:bg-red-50 has-[:checked]:border-red-400 has-[:checked]:text-red-700 transition">
+                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-checked:bg-red-50 has-checked:border-red-400 has-checked:text-red-700 transition">
                         <input type="checkbox" name="color[]" value="Red" {{ in_array('Red', $colors) ? 'checked' : '' }}  class="hidden" />
                         Red
                     </label>
 
-                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-[:checked]:bg-green-50 has-[:checked]:border-green-400 has-[:checked]:text-green-700 transition">
+                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-checked:bg-green-50 has-checked:border-green-400 has-checked:text-green-700 transition">
                         <input type="checkbox" name="color[]" value="Green" {{ in_array('Green', $colors) ? 'checked' : '' }}  class="hidden" />
                         Green
                     </label>
 
-                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-[:checked]:bg-purple-50 has-[:checked]:border-purple-400 has-[:checked]:text-purple-700 transition">
+                    <label class="flex items-center gap-2 cursor-pointer px-3 py-1.5 rounded-full border border-gray-300 text-sm font-medium text-gray-700 has-checked:bg-purple-50 has-checked:border-purple-400 has-checked:text-purple-700 transition">
                         <input type="checkbox" name="color[]" value="Colorless" {{ in_array('Colorless', $colors) ? 'checked' : '' }}  class="hidden" />
                         Colorless
                     </label>

--- a/mtg-storefront/resources/views/products/index.blade.php
+++ b/mtg-storefront/resources/views/products/index.blade.php
@@ -4,7 +4,7 @@
 
 <section class="flex justify-between items-end">
 <!-- Sorting options -->
-<div class="inline-block min-w-[200px]">    
+<div class="inline-block min-w-50">    
   <label for="sorting" class="block mb-1 text-sm text-slate-800">
     Sort by
   </label>  
@@ -75,7 +75,7 @@
     <tbody>
         @foreach ($products as $product)
         <tr class="h-fit">
-            <td class="border border-gray-300 px-4 py-2"><img src="{{ $product->image }}" width="50"></td>
+            <td class="border border-gray-300 px-4 py-2"><img src="{{ $product->image ? (Str::startsWith($product->image, 'http') ? $product->image : asset('storage/' . $product->image)) : 'https://placehold.co/400x400?text=No+Image+Uploaded' }}"  width="50"></td>
             <td class="border border-gray-300 px-4 py-2">{{ $product->product_name }}</td>
             <td class="border border-gray-300 px-4 py-2">{{ $product->category_id }}</td>
             <td class="border border-gray-300 px-4 py-2">{{ $product->price }}</td>


### PR DESCRIPTION
Updated image sources on views/products/edit and index so that the image can be sourced locally if uploaded as well as from the seeder. Also updated logic so that a placeholder image is displayed if no image has been uploaded/the uploaded image has been removed. Additionally, reformatted tailwindcss to resolve warnings on create, edit, and index products views.