### PR TITLE
Fix: Updated color values 

### DIFF
--- a/mtg-storefront/database/factories/SingleProductFactory.php
+++ b/mtg-storefront/database/factories/SingleProductFactory.php
@@ -19,7 +19,7 @@ class SingleProductFactory extends Factory
         return [
             'product_id' => \App\Models\Product::factory()->state(['category_id' => 1]),
             'rarity' => fake()->randomElement(['Common', 'Uncommon', 'Rare', 'Mythic']),
-            'color' => fake()->randomElement(['blue', 'red', 'green', 'black', 'colorless', 'white']),
+            'color' => fake()->randomElement(['Blue', 'Red', 'Green', 'Black', 'Colorless', 'White']),
             'number' => fake()->numberBetween(0, 500),
             'set_name_single' => fake()->randomElement([
                 'MH3',

--- a/mtg-storefront/database/seeders/MtgSeeder.php
+++ b/mtg-storefront/database/seeders/MtgSeeder.php
@@ -69,14 +69,14 @@ class MtgSeeder extends Seeder
 
             $colors = $card['colors'] ?? [];
             $colorMap = [
-                'W' => 'white',
-                'U' => 'blue',
-                'B' => 'black',
-                'R' => 'red',
-                'G' => 'green',
+                'W' => 'White',
+                'U' => 'Blue',
+                'B' => 'Black',
+                'R' => 'Red',
+                'G' => 'Green',
             ];
             $colorString = empty($colors)
-                ? 'colorless'
+                ? 'Colorless'
                 : implode(',', array_map(fn($c) => $colorMap[$c] ?? $c, $colors));
 
             $product = Product::create([


### PR DESCRIPTION
Resolves #50 by updating color values in mtgseeder and single product factory so that they are sending in a matching value to established color values in the edit/create forms