### PR TITLE
Fix: Color Title and Content

### DIFF
--- a/mtg-storefront/resources/views/products/show.blade.php
+++ b/mtg-storefront/resources/views/products/show.blade.php
@@ -120,8 +120,8 @@
                             @endif
                             @if ($product->single->color)
                                 <div>
-                                    <dt class="text-xs text-gray-400 uppercase tracking-wider mb-0.5">Color</dt>
-                                    <dd class="text-gray-800 font-medium">{{ $product->single->color }}</dd>
+                                    <dt class="text-xs text-gray-400 uppercase tracking-wider mb-0.5">Color(s)</dt>
+                                    <dd class="text-gray-800 font-medium">{{ implode(', ', explode(',', $product->single->color)) }}</dd>
                                 </div>
                             @endif
                             @if ($product->single->number)


### PR DESCRIPTION
Resolves #76 by updating the color title and adding the implode/explode to the colors output so that they don't show up as an unseparated string